### PR TITLE
Archive/tdd april 17 2019

### DIFF
--- a/lib/data/rotor_command.dart
+++ b/lib/data/rotor_command.dart
@@ -21,7 +21,7 @@ class RotorCommand {
   }
 
   String toShorthand() {
-    return ' ';
+    return throttleToShorthand() + ' ' + headingToShorthand();
   }
 
   String throttleToShorthand() {

--- a/lib/data/rotor_command.dart
+++ b/lib/data/rotor_command.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 class RotorCommand {
   int throttleVal = 2;
   int headingVal = 2;
@@ -13,6 +15,31 @@ class RotorCommand {
   String toShorthand() {
     return ' ';
   }
+
+  String throttleToShorthand() {
+    String abv = '';
+    switch(this.throttleDir){
+      case ThrottleDirection.FORWARD:
+        abv = 'F';
+        break;
+      case ThrottleDirection.BACKWARD:
+        abv = 'B';
+        break;
+      default:
+        abv = 'N';
+        break;
+    }
+
+    return abv +_formatInt(throttleVal);
+  }
+
+  String _formatInt(int i) {
+    NumberFormat numberFormat = NumberFormat();
+    numberFormat.minimumIntegerDigits = 3;
+    numberFormat.maximumIntegerDigits = 3;
+    return numberFormat.format(i);
+  }
+
 }
 
 enum ThrottleDirection { FORWARD, NEUTRAL, BACKWARD }

--- a/lib/data/rotor_command.dart
+++ b/lib/data/rotor_command.dart
@@ -1,63 +1,19 @@
-import 'package:intl/intl.dart';
-
 class RotorCommand {
-  int _throttleVal;
-  int _headingVal;
-
+  int throttleVal = 2;
+  int headingVal = 2;
   final ThrottleDirection throttleDir;
   final HeadingDirection headingDir;
 
-  get throttleVal => _throttleVal;
-
-  get headingVal => _headingVal;
-
   RotorCommand(
-      {throttleVal = 0,
-      headingVal = 0,
+      {this.throttleVal = 0,
+      this.headingVal = 0,
       this.throttleDir = ThrottleDirection.NEUTRAL,
-      this.headingDir = HeadingDirection.MIDDLE}) {
-    _throttleVal = num.parse(throttleVal.toString()).clamp(0, 100).toInt();
-    _headingVal = num.parse(headingVal.toString()).clamp(0, 100).toInt();
-  }
+      this.headingDir = HeadingDirection.NEUTRAL});
 
   String toShorthand() {
-    NumberFormat outputFormat = NumberFormat();
-    outputFormat.maximumIntegerDigits = 3;
-    outputFormat.minimumIntegerDigits = 3;
-
-    return _abbreviateThrottleDir(throttleDir) +
-        outputFormat.format(throttleVal) +
-        " " +
-        _abbreviateHeadingDir(headingDir) +
-        outputFormat.format(headingVal);
-  }
-
-  String _abbreviateThrottleDir(ThrottleDirection td) {
-    switch (td) {
-      case ThrottleDirection.FORWARD:
-        return 'F';
-        break;
-      case ThrottleDirection.BACKWARD:
-        return 'B';
-        break;
-      default:
-        return 'N';
-    }
-  }
-
-  String _abbreviateHeadingDir(HeadingDirection hd) {
-    switch (hd) {
-      case HeadingDirection.PORT:
-        return 'L';
-        break;
-      case HeadingDirection.MIDDLE:
-        return 'N';
-        break;
-      default:
-        return 'R';
-    }
+    return ' ';
   }
 }
 
 enum ThrottleDirection { FORWARD, NEUTRAL, BACKWARD }
-enum HeadingDirection { PORT, MIDDLE, STARBOARD }
+enum HeadingDirection { PORT, NEUTRAL, STARBOARD }

--- a/lib/data/rotor_command.dart
+++ b/lib/data/rotor_command.dart
@@ -33,6 +33,23 @@ class RotorCommand {
     return abv +_formatInt(throttleVal);
   }
 
+  String headingToShorthand() {
+    String abv = '';
+    switch(this.headingDir) {
+      case HeadingDirection.PORT:
+        abv = 'L';
+        break;
+      case HeadingDirection.STARBOARD:
+        abv = 'R';
+        break;
+      default:
+        abv = 'N';
+        break;
+    }
+    
+    return abv + _formatInt(headingVal);
+  }
+
   String _formatInt(int i) {
     NumberFormat numberFormat = NumberFormat();
     numberFormat.minimumIntegerDigits = 3;

--- a/lib/data/rotor_command.dart
+++ b/lib/data/rotor_command.dart
@@ -1,16 +1,24 @@
 import 'package:intl/intl.dart';
 
 class RotorCommand {
-  int throttleVal = 2;
-  int headingVal = 2;
+  int _throttleVal = 2;
+  get throttleVal => _throttleVal;
+
+  int _headingVal = 2;
+  get headingVal => _headingVal;
+  
   final ThrottleDirection throttleDir;
   final HeadingDirection headingDir;
 
   RotorCommand(
-      {this.throttleVal = 0,
-      this.headingVal = 0,
+      {int throttleVal = 0,
+      int headingVal = 0,
       this.throttleDir = ThrottleDirection.NEUTRAL,
-      this.headingDir = HeadingDirection.NEUTRAL});
+      this.headingDir = HeadingDirection.NEUTRAL}){
+    
+    this._throttleVal = throttleVal.clamp(0, 100);
+    this._headingVal = headingVal.clamp(0, 100);
+  }
 
   String toShorthand() {
     return ' ';

--- a/lib/ui/vehiclemonitor/vehicle_controls_page_content.dart
+++ b/lib/ui/vehiclemonitor/vehicle_controls_page_content.dart
@@ -105,12 +105,12 @@ class VehicleControlsPageContentState
             _buildControlPanelButton(
                 "GO!",
                 (pressingDown) =>
-                    _executeCommand(RotorCommand(throttleVal: 20, throttleDir: ThrottleDirection.FORWARD, headingDir: HeadingDirection.MIDDLE, headingVal: 0)),
+                    _executeCommand(RotorCommand(throttleVal: 20, throttleDir: ThrottleDirection.FORWARD, headingDir: HeadingDirection.NEUTRAL, headingVal: 0)),
                 colorOverride: Colors.green),
             _buildControlPanelButton(
                 "STOP!",
                 (pressingDown) =>
-                    _executeCommand(RotorCommand(throttleVal: 0, throttleDir: ThrottleDirection.NEUTRAL, headingDir: HeadingDirection.MIDDLE, headingVal: 0)),
+                    _executeCommand(RotorCommand(throttleVal: 0, throttleDir: ThrottleDirection.NEUTRAL, headingDir: HeadingDirection.NEUTRAL, headingVal: 0)),
                 colorOverride: Colors.red)
           ],
         )

--- a/test/data/command_streamer_test.dart
+++ b/test/data/command_streamer_test.dart
@@ -24,6 +24,10 @@ void main() {
     expect(cmdStream, isInstanceOf<Stream<RotorCommand>>());
     await cmdStream.first.then((firstItem) {
       expect(firstItem, isNotNull);
+      expect(firstItem.throttleDir, ThrottleDirection.NEUTRAL);
+      expect(firstItem.throttleVal, 0);
+      expect(firstItem.headingDir, HeadingDirection.NEUTRAL);
+      expect(firstItem.headingVal, 0);
     });
   });
 

--- a/test/data/rotor_command_test.dart
+++ b/test/data/rotor_command_test.dart
@@ -45,4 +45,21 @@ void main() {
 
   });
 
+  test("Should produce correct shorthand for heading direction", () {
+
+    expect(RotorCommand(headingDir: HeadingDirection.PORT).headingToShorthand(), 'L000');
+    expect(RotorCommand(headingDir: HeadingDirection.NEUTRAL).headingToShorthand(), 'N000');
+    expect(RotorCommand(headingDir: HeadingDirection.STARBOARD).headingToShorthand(), 'R000');
+
+  });
+
+  test("Should produce correct shorthand for heading value", () {
+
+    expect(RotorCommand(headingVal: 0).headingToShorthand(), 'N000');
+    expect(RotorCommand(headingVal: 1).headingToShorthand(), 'N001');
+    expect(RotorCommand(headingVal: 12).headingToShorthand(), 'N012');
+    expect(RotorCommand(headingVal: 100).headingToShorthand(), 'N100');
+
+  });
+
 }

--- a/test/data/rotor_command_test.dart
+++ b/test/data/rotor_command_test.dart
@@ -62,6 +62,31 @@ void main() {
 
   });
 
+  test("Should produce complete shorthand", () {
+
+    //ARRANGE
+    var cmdA = RotorCommand(
+      throttleDir: ThrottleDirection.FORWARD, 
+      throttleVal: 77,
+      headingDir: HeadingDirection.PORT,
+      headingVal: 55);
+
+    var cmdB = RotorCommand(
+      throttleDir: ThrottleDirection.BACKWARD,
+      throttleVal: 100,
+      headingDir: HeadingDirection.STARBOARD,
+      headingVal: 33);
+    
+    //ACT
+    var resultA = cmdA.toShorthand();
+    var resultB = cmdB.toShorthand();
+
+    //ASSERT
+    expect(resultA, 'F077 L055');
+    expect(resultB, 'B100 R033');
+
+  });
+
   test("Should truncate values outside of bounds", () {
 
     expect(RotorCommand(throttleVal: -10).throttleVal, 0);

--- a/test/data/rotor_command_test.dart
+++ b/test/data/rotor_command_test.dart
@@ -27,4 +27,22 @@ void main() {
     expect(rotorCommand.throttleDir, ThrottleDirection.BACKWARD);
     expect(rotorCommand.headingDir, HeadingDirection.STARBOARD);
   });
+
+  test("Should produce correct shorthand for throttle direction", () {
+    
+    expect(RotorCommand(throttleDir: ThrottleDirection.FORWARD).throttleToShorthand(), 'F000');
+    expect(RotorCommand(throttleDir: ThrottleDirection.NEUTRAL).throttleToShorthand(), 'N000');
+    expect(RotorCommand(throttleDir: ThrottleDirection.BACKWARD).throttleToShorthand(), 'B000');
+
+  });
+
+  test("Should produce correct shorthand for throttle value", () {
+
+    expect(RotorCommand(throttleVal: 0).throttleToShorthand(), 'N000');
+    expect(RotorCommand(throttleVal: 1).throttleToShorthand(), 'N001');
+    expect(RotorCommand(throttleVal: 12).throttleToShorthand(), 'N012');
+    expect(RotorCommand(throttleVal: 100).throttleToShorthand(), 'N100');
+
+  });
+
 }

--- a/test/data/rotor_command_test.dart
+++ b/test/data/rotor_command_test.dart
@@ -3,73 +3,13 @@ import 'package:mobileclient/data/rotor_command.dart';
 
 void main() {
   test("Should construct with default values", () {
-    RotorCommand rotorCommand = RotorCommand();
+    //ARRANGE
+    var rotorCommand = RotorCommand();
 
+    //ACT & ASSERT
     expect(rotorCommand.throttleVal, 0);
     expect(rotorCommand.headingVal, 0);
     expect(rotorCommand.throttleDir, ThrottleDirection.NEUTRAL);
-    expect(rotorCommand.headingDir, HeadingDirection.MIDDLE);
+    expect(rotorCommand.headingDir, HeadingDirection.NEUTRAL);
   });
-
-  //This is technically a constructor test... which is kinda stupid...
-  test("Should construct with specified values", () {
-    RotorCommand rotorCommand = RotorCommand(
-        throttleVal: 10,
-        headingVal: 20,
-        throttleDir: ThrottleDirection.BACKWARD,
-        headingDir: HeadingDirection.STARBOARD);
-
-
-    expect(rotorCommand.throttleVal, 10);
-    expect(rotorCommand.headingVal, 20);
-    expect(rotorCommand.throttleDir, ThrottleDirection.BACKWARD);
-    expect(rotorCommand.headingDir, HeadingDirection.STARBOARD);
-  });
-
-  test("Should produce correct abbreviation for throttle direction", () {
-
-    expect(RotorCommand(throttleDir: ThrottleDirection.FORWARD).toShorthand(), "F000 N000");
-    expect(RotorCommand(throttleDir: ThrottleDirection.NEUTRAL).toShorthand(), "N000 N000");
-    expect(RotorCommand(throttleDir: ThrottleDirection.BACKWARD).toShorthand(), "B000 N000");
-  });
-
-  test("Should produce correct value for throttle", () {
-
-    expect(RotorCommand(throttleVal: 1).toShorthand(), "N001 N000");
-    expect(RotorCommand(throttleVal: 12).toShorthand(), "N012 N000");
-    expect(RotorCommand(throttleVal: 100).toShorthand(), "N100 N000");
-  });
-
-  test("Should produce correct abbreviation for heading direction", () {
-
-    expect(RotorCommand(headingDir: HeadingDirection.PORT).toShorthand(), "N000 L000");
-    expect(RotorCommand(headingDir: HeadingDirection.MIDDLE).toShorthand(), "N000 N000");
-    expect(RotorCommand(headingDir: HeadingDirection.STARBOARD).toShorthand(), "N000 R000");
-
-  });
-
-  test("Should produce correct value for heading", () {
-
-    expect(RotorCommand(headingVal: 1).toShorthand(), "N000 N001");
-    expect(RotorCommand(headingVal: 12).toShorthand(), "N000 N012");
-    expect(RotorCommand(headingVal: 100).toShorthand(), "N000 N100");
-  });
-
-  test("Should truncate values outside of bounds", () {
-
-    RotorCommand negativeOOBThrottle = RotorCommand(throttleVal: -20);
-    RotorCommand positiveOOBThrottle = RotorCommand(throttleVal: 120);
-
-    RotorCommand negativeOOBHeading = RotorCommand(headingVal: -30);
-    RotorCommand positiveOOBHeading = RotorCommand(headingVal: 130);
-
-    expect(negativeOOBThrottle.throttleVal, 0);
-    expect(positiveOOBThrottle.throttleVal, 100);
-
-    expect(negativeOOBHeading.headingVal, 0);
-    expect(positiveOOBHeading.headingVal, 100);
-
-  });
-
-
 }

--- a/test/data/rotor_command_test.dart
+++ b/test/data/rotor_command_test.dart
@@ -62,4 +62,14 @@ void main() {
 
   });
 
+  test("Should truncate values outside of bounds", () {
+
+    expect(RotorCommand(throttleVal: -10).throttleVal, 0);
+    expect(RotorCommand(throttleVal: 111).throttleVal, 100);
+
+    expect(RotorCommand(headingVal: -20).headingVal, 0);
+    expect(RotorCommand(headingVal: 222).headingVal, 100);
+
+  });
+
 }

--- a/test/data/rotor_command_test.dart
+++ b/test/data/rotor_command_test.dart
@@ -12,4 +12,19 @@ void main() {
     expect(rotorCommand.throttleDir, ThrottleDirection.NEUTRAL);
     expect(rotorCommand.headingDir, HeadingDirection.NEUTRAL);
   });
+
+  test("Should construct with specified values", () {
+    //ARRANGE
+    var rotorCommand = RotorCommand(
+        throttleVal: 10,
+        headingVal: 20,
+        throttleDir: ThrottleDirection.BACKWARD,
+        headingDir: HeadingDirection.STARBOARD);
+
+    //ACT & ASSERT
+    expect(rotorCommand.throttleVal, 10);
+    expect(rotorCommand.headingVal, 20);
+    expect(rotorCommand.throttleDir, ThrottleDirection.BACKWARD);
+    expect(rotorCommand.headingDir, HeadingDirection.STARBOARD);
+  });
 }


### PR DESCRIPTION
Revised version of RotorCommand class and tests.
Tests are no longer tightly coupled to the full shorthand strings. Makes for more flexible testing.